### PR TITLE
Use correct context when evaluating array methods.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,13 +76,16 @@ module.exports = function (ast, vars) {
             var callee = walk(node.callee);
             if (callee === FAIL) return FAIL;
             
+            var ctx = node.callee.object ? walk(node.callee.object) : FAIL;
+            if (ctx === FAIL) ctx = null;
+
             var args = [];
             for (var i = 0, l = node.arguments.length; i < l; i++) {
                 var x = walk(node.arguments[i]);
                 if (x === FAIL) return FAIL;
                 args.push(x);
             }
-            return callee.apply(null, args);
+            return callee.apply(ctx, args);
         }
         else if (node.type === 'MemberExpression') {
             var obj = walk(node.object);

--- a/test/eval.js
+++ b/test/eval.js
@@ -35,3 +35,11 @@ test('boolean', function (t) {
     var ast = parse(src).body[0].expression;
     t.deepEqual(evaluate(ast), [ true, true, true, true ]);
 });
+
+test('array methods', function(t) {
+    t.plan(1);
+
+    var src = '[1, 2, 3].map(function(n) { return n * 2 })';
+    var ast = parse(src).body[0].expression;
+    t.deepEqual(evaluate(ast), [2, 4, 6]);
+})


### PR DESCRIPTION
Allows the following examples to be statically evaluated:

``` javascript
;[1, 2, 3].map(function(n) { return n * 2 })

;['multi'
, 'line'
, 'string'].join('\n')
```

Previously, the context was always assumed to be null which doesn't play nice with Array's prototype methods.

Thanks! :)
