### PR TITLE
Handle evaluation of LogicalExpression

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = function (ast, vars) {
             }
             return obj;
         }
-        else if (node.type === 'BinaryExpression') {
+        else if (node.type === 'BinaryExpression' ||
+                 node.type === 'LogicalExpression') {
             var l = walk(node.left);
             if (l === FAIL) return FAIL;
             var r = walk(node.right);

--- a/test/eval.js
+++ b/test/eval.js
@@ -5,10 +5,10 @@ var parse = require('esprima').parse;
 test('resolved', function (t) {
     t.plan(1);
     
-    var src = '[1,2,3+4*10+n,foo(3+5),obj[""+"x"].y]';
+    var src = '[1,2,3+4*10+(n||6),foo(3+5),obj[""+"x"].y]';
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast, {
-        n: 6,
+        n: false,
         foo: function (x) { return x * 100 },
         obj: { x: { y: 555 } }
     });


### PR DESCRIPTION
I don't know why the `LogicalExpression` operators were listed together with `BinaryExpression` operators, maybe the parser api ast have changed. Either way I made the smallest change to make this work with current esprima output for logical expressions.

It would be more consistent if logical expressions had their own branch, but on the other hand, this way it is more backwards compatible.
