### PR TITLE
Adding ability to provide an optional thisArg when evaluating expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var unparse = require('escodegen').generate;
 
-module.exports = function (ast, vars) {
+module.exports = function (ast, vars, thisArg) {
     if (!vars) vars = {};
+    if (!thisArg) thisArg = {};
     var FAIL = {};
     
     var result = (function walk (node) {
@@ -109,6 +110,9 @@ module.exports = function (ast, vars) {
                 return vars[key];
             });
             return Function(keys.join(', '), 'return ' + unparse(node)).apply(null, vals);
+        }
+        else if (node.type === 'ThisExpression') {
+            return thisArg;
         }
         else return FAIL;
     })(ast);

--- a/readme.markdown
+++ b/readme.markdown
@@ -61,11 +61,11 @@ console.log(evaluate(ast, {
 var evaluate = require('static-eval');
 ```
 
-## evaluate(ast, vars={})
+## evaluate(ast, vars={}, thisArg={})
 
 Evaluate the [esprima](https://npmjs.org/package/esprima)-parsed abstract syntax
-tree object `ast` with an optional collection of variables `vars` to use in the
-static expression resolution.
+tree object `ast` with an optional collection of variables `vars` and an optional
+context `thisArg` to use in the static expression resolution.
 
 If the expression contained in `ast` can't be statically resolved, `evaluate()`
 returns undefined.

--- a/test/eval.js
+++ b/test/eval.js
@@ -51,3 +51,25 @@ test('array methods with vars', function(t) {
     var ast = parse(src).body[0].expression;
     t.deepEqual(evaluate(ast, {x: 2}), [2, 4, 6]);
 });
+
+test('resolved vars and resolved thisArg', function(t) {
+    t.plan(1);
+
+    var src = 'this.foo.bar === var1 && this.foo2() == var2';
+    var ast = parse(src).body[0].expression;
+    var value1 = 'value1';
+    var value2 = 1;
+    var vars = {
+        var1: value1,
+        var2: value2
+    }
+    var thisArg = {
+        foo: {
+            bar: value1
+        },
+        foo2: function() {
+            return value2;
+        }
+    }
+    t.deepEqual(evaluate(ast, vars, thisArg), true);
+});


### PR DESCRIPTION
In a project I'm currently working on, I am relying on static-eval but would like to provide a context for the code that is being evaluated. This pull request makes that possible.

All tests pass.