### PR TITLE
Add support for "this" via explicitly named var

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,12 @@ module.exports = function (ast, vars) {
             }
             else return FAIL;
         }
+        else if (node.type === 'ThisExpression') {
+            if ({}.hasOwnProperty.call(vars, 'this')) {
+                return vars['this'];
+            }
+            else return FAIL;
+        }
         else if (node.type === 'CallExpression') {
             var callee = walk(node.callee);
             if (callee === FAIL) return FAIL;

--- a/test/eval.js
+++ b/test/eval.js
@@ -51,3 +51,14 @@ test('array methods with vars', function(t) {
     var ast = parse(src).body[0].expression;
     t.deepEqual(evaluate(ast, {x: 2}), [2, 4, 6]);
 });
+
+test('evaluate this', function(t) {
+    t.plan(1);
+
+    var src = 'this.x + this.y.z';
+    var ast = parse(src).body[0].expression;
+    var res = evaluate(ast, {
+        'this': { x: 1, y: { z: 100 } }
+    });
+    t.equal(res, 101);
+});


### PR DESCRIPTION
This PR adds support for the `this` identifier via an explicitly named var:

```js
var src = 'this.x + this.y.z';
var ast = parse(src).body[0].expression;
var res = evaluate(ast, {
    'this': { x: 1, y: { z: 100 } }
});
t.equal(res, 101);
```

An alternative would be to use the actual `this` value inside `evaluate()` if `this !== global`, but this feels more explicit to me.