### PR TITLE
Fix exception instead of failure when parsing CallExpressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ module.exports = function (ast, vars) {
         else if (node.type === 'CallExpression') {
             var callee = walk(node.callee);
             if (callee === FAIL) return FAIL;
+            if (typeof callee !== 'function') return FAIL;
             
             var ctx = node.callee.object ? walk(node.callee.object) : FAIL;
             if (ctx === FAIL) ctx = null;


### PR DESCRIPTION
Transforming parsers generated with [jison](https://www.npmjs.com/package/jison) with [brfs](https://www.npmjs.com/package/brfs) would crash when static-eval attempted to parse this code:

```javascript
var source = require('fs').readFileSync(require('path').normalize(x), 'utf8');

TypeError: callee.apply is not a function while parsing file: /tmp/b
    at walk (/Users/admin/games/voxeljs/static-eval/index.js:89:27)
    at walk (/Users/admin/games/voxeljs/static-eval/index.js:92:23)
    at walk (/Users/admin/games/voxeljs/static-eval/index.js:77:26)
    at walk (/Users/admin/games/voxeljs/static-eval/index.js:85:25)
    at module.exports (/Users/admin/games/voxeljs/static-eval/index.js:114:7)
    at traverse (/Users/admin/games/voxeljs/static-module/index.js:256:23)
    at walk (/Users/admin/games/voxeljs/static-module/index.js:208:13)
    at walk (/Users/admin/games/voxeljs/static-module/node_modules/falafel/index.js:49:9)
    at /Users/admin/games/voxeljs/static-module/node_modules/falafel/index.js:46:17
    at forEach (/Users/admin/games/voxeljs/static-module/node_modules/falafel/node_modules/foreach/index.js:12:16)
```

This PR fixes the crash, and correctly returns `FAIL` so it won't be transformed, as expected (it cannot be, since it is dynamic). 

---

Smaller (but nonsensical) test case:

```
var source = require('fs').readFileSync(require('path'));
```

require() parses as not a function, but an object `{ resolve: …}`, and then static-eval tries to call it, causing this exception. These other cases parse correctly (not transformed, expected):

```javascript
var path = require('path').normalize(x);
var source = require('fs').readFileSync(path, 'utf8');

function f() { return '/tmp/foo'; }
var source = require('fs').readFileSync(f());
```

only `readFileSync(require…)` causes the crash, which this PR fixes (by gracefully failing instead).