### PR TITLE
Security Issues

### DIFF
--- a/test/eval.js
+++ b/test/eval.js
@@ -62,3 +62,21 @@ test('evaluate this', function(t) {
     });
     t.equal(res, 101);
 });
+
+test('FunctionExpression unresolved', function(t) {
+    t.plan(1);
+
+    var src = '(function(){console.log("Not Good")})';
+    var ast = parse(src).body[0].expression;
+    var res = evaluate(ast, {});
+    t.equal(res, undefined);
+});
+
+test('MemberExpressions from Functions unresolved', function(t) {
+    t.plan(1);
+
+    var src = '(function () {}).constructor';
+    var ast = parse(src).body[0].expression;
+    var res = evaluate(ast, {});
+    t.equal(res, undefined);
+});


### PR DESCRIPTION
This should address the unsafe code in ExpressionStatement / FunctionExpression blocks:

``` javascript
var src = '(function(){console.log(process.pid)})()';
```

As well as the issue described at https://github.com/substack/static-eval/issues/4. The current fix for this is to not all any member expressions to resolve from a function. 

``` javascript
[1,2,3].map // will be allowed
[1,2,3].map.constructor // should be blocked
```

I believe the next step should be to try to refactor out the dynamic Function call completely.